### PR TITLE
🐛 Fix summary-image-large -> summary-large-image for twitter preview

### DIFF
--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -79,7 +79,7 @@ const PostPage = ({
         }}
         twitter={{
           handle: "@spoonsandcode",
-          cardType: "summary_image_large",
+          cardType: "summary_large_image",
         }}
       />
       <Layout alignNav={NavAlign.LEFT}>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -49,6 +49,10 @@ export const Home = ({ posts, image }) => {
             },
           ],
         }}
+        twitter={{
+          handle: "@spoonsandcode",
+          cardType: "summary_large_image",
+        }}
       />
       <section className="flex flex-col w-fit justify-start">
         <div className="flex flex-col">


### PR DESCRIPTION
typo for twitter card previews (named incorrectly)